### PR TITLE
Use a GitHub Action Service for MySQL

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,15 @@ jobs:
           - 'trilogy'
           - 'mysql2'
 
+    services:
+      mariadb:
+        image: mariadb:10.6
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: scenic_mysql_adapter_test
+        ports:
+          - 3306:3306
+
     steps:
       - uses: actions/checkout@v3
 
@@ -25,12 +34,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
-      - name: Start and create DB
-        run: |
-          sudo service mysql start
-          sleep 10
-          mysql -u root -proot -e "CREATE DATABASE scenic_mysql_adapter_test;"
 
       - name: Run tests
         env:


### PR DESCRIPTION
I think this would solve the auth issue with Trilogy. If not we can alter the user to no longer use caching_sha2.